### PR TITLE
Update HubspotWebViewClient to support webview loading & error state

### DIFF
--- a/hubspot/src/main/java/com/hubspot/mobilesdk/widget/HubspotWebViewClient.kt
+++ b/hubspot/src/main/java/com/hubspot/mobilesdk/widget/HubspotWebViewClient.kt
@@ -56,6 +56,9 @@ internal class HubspotWebViewClient : WebViewClient() {
             nativeApp.postMessage("info","Starting main load script");
             if (window.HubSpotConversations) {
                 configureHubspotConversations();
+            }
+            else if (Array.isArray(window.hsConversationsOnReady)) {
+                window.hsConversationsOnReady.push(configureHubspotConversations);
             } else {
                 window.hsConversationsOnReady = [configureHubspotConversations];
             }


### PR DESCRIPTION
Update HubspotWebViewClient to support webview loading & error state

See the same change in iOS repo - https://github.com/HubSpot/mobile-chat-sdk-ios/pull/1/files