### PR TITLE
Implement the fix to open a url which starts from http

### DIFF
--- a/hubspot/src/main/AndroidManifest.xml
+++ b/hubspot/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <application>
+    <application android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name="com.hubspot.mobilesdk.HubspotWebActivity"
             android:exported="true"

--- a/hubspot/src/main/res/xml/network_security_config.xml
+++ b/hubspot/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  network_security_config.xml
+  Hubspot Mobile SDK
+  Copyright (c) 2024 Hubspot, Inc.
+  -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
https://bugs.tapadoo.com/issue/HMSDK-155

Implement the fix to open a url which starts from http

Description:
Some of the links which starts from http:// rather than https:// are not loading the data inside the weview.

Client wants to use the hubspot knowledge base article and hubspot provided the link for that which has http:. Because the link is not secure, webview doesn't open the link.

More information from slack thread: https://tapadoo.slack.com/archives/C06V0KZFFL6/p1716377307908839

**Before Fix**

https://github.com/HubSpot/mobile-chat-sdk-android/assets/5118769/0c778267-61c8-41f1-97a5-265d3e7baa49



**After Fix**


https://github.com/HubSpot/mobile-chat-sdk-android/assets/5118769/279d2086-11ae-4869-b5ab-76509c9cb018


