### PR TITLE
Chat screen close feature

### DIFF
--- a/demo/src/main/java/com/example/demo/bottomnavigation/WebviewFragment.kt
+++ b/demo/src/main/java/com/example/demo/bottomnavigation/WebviewFragment.kt
@@ -32,6 +32,11 @@ class WebviewFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.webview.show()
+        with(binding.webview) {
+            addChatScreenCloseListener {
+                requireActivity().run { runOnUiThread { onBackPressedDispatcher.onBackPressed() } }
+            }
+            show()
+        }
     }
 }

--- a/hubspot/src/main/java/com/hubspot/mobilesdk/HubspotWebActivity.kt
+++ b/hubspot/src/main/java/com/hubspot/mobilesdk/HubspotWebActivity.kt
@@ -45,6 +45,7 @@ class HubspotWebActivity : AppCompatActivity() {
         with(binding.hubspotwebview) {
             settings.javaScriptEnabled = true
             show(chatFlowId, pushData)
+            addChatScreenCloseListener { finish() }
             webChromeClient = object : WebChromeClient() {
                 override fun onShowFileChooser(webView: WebView?, filePathCallback: ValueCallback<Array<Uri>>?, fileChooserParams: FileChooserParams?): Boolean {
                     // When we press back button without selecting any component(image/video/audio etc.),


### PR DESCRIPTION
- Updated the sdk code to listen to a new JS event `sdkCloseButtonClick `
- Added a `addChatScreenCloseListener` to the HubspotWebView to allow developers to listen to the close button event
- Updated the demo code to show the usage of the `addChatScreenCloseListner`