### PR TITLE
Handle edge to edge UI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
 
     afterEvaluate {
         extensions.findByType<com.android.build.gradle.BaseExtension>()?.run {
-            compileSdkVersion(34)
+            compileSdkVersion(35)
             defaultConfig {
                 minSdk = 26
                 targetSdk = 34

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ subprojects {
             compileSdkVersion(35)
             defaultConfig {
                 minSdk = 26
-                targetSdk = 34
+                targetSdk = 35
             }
             compileOptions {
                 sourceCompatibility = JavaVersion.VERSION_17

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
             android:exported="true"
             android:windowSoftInputMode="adjustResize" />
 
+        <activity android:name="com.hubspot.mobilesdk.HubspotWebActivity"
+            android:theme="@style/Theme.HubspotChat"/>
+
         <service
             android:name=".firebase.DemoFirebaseMessagingService"
             android:exported="false">

--- a/demo/src/main/java/com/example/demo/MainActivity.kt
+++ b/demo/src/main/java/com/example/demo/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.demo.databinding.ActivityMainBinding
+import com.example.demo.extention.applyEdgeToEdgeInsets
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.hubspot.mobilesdk.HubspotManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,7 +53,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
-
+        applyEdgeToEdgeInsets()
         val navView: BottomNavigationView = binding.bottomNavView
         val navController = findNavController(R.id.navHostFragment)
         appBarConfiguration = AppBarConfiguration(

--- a/demo/src/main/java/com/example/demo/extention/Activity.kt
+++ b/demo/src/main/java/com/example/demo/extention/Activity.kt
@@ -1,0 +1,40 @@
+/*************************************************
+ * Activity.kt
+ * Hubspot Mobile SDK
+ *
+ * Copyright (c) 2025 Hubspot, Inc.
+ ************************************************/
+package com.example.demo.extention
+
+import android.app.Activity
+import android.os.Build
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.example.demo.R
+
+fun Activity.applyEdgeToEdgeInsets() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        val view = findViewById<View>(android.R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+            //Retrieve the Insets for system bars, display cutouts and ime
+            val bars = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or
+                        WindowInsetsCompat.Type.displayCutout() or
+                        WindowInsetsCompat.Type.ime()
+            )
+            //Update the padding for the screen content with the retrieved insets
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+                bottom = bars.bottom,
+            )
+            //Set background color for the decor view
+            window.decorView.setBackgroundColor(ContextCompat.getColor(this, R.color.orange))
+            windowInsets
+        }
+    }
+}

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/white">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"

--- a/demo/src/main/res/values/themes.xml
+++ b/demo/src/main/res/values/themes.xml
@@ -6,4 +6,9 @@
 
     <style name="Theme.DemoApp" parent="Base.Theme.DemoApp" />
 
+    <!--Theme to set the system bar colors for HubspotWebActivity-->
+    <style name="Theme.HubspotChat" parent="Base.Theme.DemoApp">
+        <item name="android:windowBackground">@color/orange</item>
+    </style>
+
 </resources>

--- a/hubspot/src/main/java/com/hubspot/mobilesdk/HubspotWebActivity.kt
+++ b/hubspot/src/main/java/com/hubspot/mobilesdk/HubspotWebActivity.kt
@@ -10,11 +10,15 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import com.hubspot.mobilesdk.databinding.ActivityWebviewBinding
 import com.hubspot.mobilesdk.firebase.HubspotFirebaseMessagingService
 import com.hubspot.mobilesdk.firebase.HubspotFirebaseMessagingService.Companion.HS_PUSH_DATA
@@ -34,6 +38,7 @@ class HubspotWebActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityWebviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        applyEdgeToEdgeInsets()
         val chatFlowId = intent.getStringExtra(CHAT_FLOW_KEY)
         val pushData = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent.extras?.getSerializable(HS_PUSH_DATA, PushNotificationChatData::class.java)
@@ -98,6 +103,28 @@ class HubspotWebActivity : AppCompatActivity() {
             fileUploadCallback = null
         } else {
             super.onActivityResult(requestCode, resultCode, data)
+        }
+    }
+
+    private fun applyEdgeToEdgeInsets() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            val view = findViewById<View>(android.R.id.content)
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+                //Retrieve the Insets for system bars, display cutouts and ime
+                val bars = windowInsets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or
+                            WindowInsetsCompat.Type.displayCutout() or
+                            WindowInsetsCompat.Type.ime()
+                )
+                //Update the padding for the screen content with the retrieved insets
+                v.updatePadding(
+                    left = bars.left,
+                    top = bars.top,
+                    right = bars.right,
+                    bottom = bars.bottom,
+                )
+                windowInsets
+            }
         }
     }
 

--- a/hubspot/src/main/java/com/hubspot/mobilesdk/util/DeviceInformation.kt
+++ b/hubspot/src/main/java/com/hubspot/mobilesdk/util/DeviceInformation.kt
@@ -63,7 +63,7 @@ internal class DeviceInformation {
         fun getAppVersion(context: Context): String {
             return try {
                 val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-                pInfo.versionName
+                pInfo.versionName ?: "N/A"
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e)
                 "N/A"


### PR DESCRIPTION
**Changes in this PR**
1. Applied padding based on window insets to fix the overlapping issue in `HubspotWebActivity` in the Hubspot SDK for Android 15+ devices
2. Created a new theme in the `demo` app for the `HubspotWebActivity` to specify the `windowBackground` color. This color will be used by the system to set the background color behind the system bars in  `HubspotWebActivity` for Android 15+ devices
3. Updated the `demo` app screens to handle the edge-to-edge UI