### PR TITLE
Fix broken workflow for SDK doc generation and deployment to Github pages

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Doc Pages
         run: ./gradlew dokkaHtml
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ github.repository }}/docs
   deploy:
@@ -49,4 +49,4 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Changes in this PR:

- Updated the versions for 'update-pages-artifcat' and 'deploy-pages' github actions . These actions were outdated and preventing the generation and deployment of the docs to the github pages.